### PR TITLE
Feature/custom driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `laravel-printing` will be documented in this file.
 
+## 1.3.0 - 2020-09-13
+### Added
+- Add support for custom drivers
+- Add support for changing print drivers on the fly
+
 ## 1.2.2 - 2020-09-08
 ### Added
 - Add support for Laravel 8

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ return [
             'password' => env('CUPS_SERVER_PASSWORD'),
             'port' => env('CUPS_SERVER_PORT', 631),
         ],
+        
+        /*
+         * Add your custom drivers here:
+         *
+         * 'custom' => [
+         *      'driver' => 'custom_driver',
+         *      // other config for your custom driver
+         * ],
+         */
     ],
 
     /*

--- a/config/printing.php
+++ b/config/printing.php
@@ -29,6 +29,15 @@ return [
             'password' => env('CUPS_SERVER_PASSWORD'),
             'port' => env('CUPS_SERVER_PORT', 631),
         ],
+
+        /*
+         * Add your custom drivers here:
+         *
+         * 'custom' => [
+         *      'driver' => 'custom_driver',
+         *      // other config for your custom driver
+         * ],
+         */
     ],
 
     /*

--- a/docs/advanced-usage/custom-drivers.md
+++ b/docs/advanced-usage/custom-drivers.md
@@ -1,0 +1,49 @@
+---
+title: Custom Drivers
+sort: 4
+---
+
+Since: 1.3.0
+
+## Introduction
+
+If you need to use a driver that isn't supported by the package, you can easily add your own custom driver.
+Adding a custom driver will require you to add the driver's config to the `drivers` in the config file, and
+to extend the printing factory in a service provider.
+
+## Configuring a Custom Driver
+
+Add your custom driver configuration under `drivers` in `config/printing`. The minimum required for your driver config
+is a `driver` key.
+
+```php
+'driver' => 'my_custom_driver',
+
+'drivers' => [
+    ...
+    'my_custom_driver' => [
+        'driver' => 'custom', // This value is required
+        // any other configuration needed
+    ],
+],
+```
+
+You can change `custom` and `my_custom_driver` to whatever you want. Any data you specify in the configuration
+of your custom driver will be passed to the closure you provide to the printing factory when extending it.
+
+## Defining a Custom Driver
+
+Once you have your custom driver configuration defined, you need to tell the printing package how to create it. This
+is done by extending the print factory used by this package. In a service provider, you can do it like this:
+
+```php
+public function register(): void
+{
+    $this->app['printing.factory']->extend('custom', function (array $config) {
+        return new MyCustomDriver($config);    
+    });
+}
+```
+
+The value you pass in as the first parameter needs to match what you defined as **driver** in your custom
+driver's configuration earlier.

--- a/docs/advanced-usage/multiple-drivers.md
+++ b/docs/advanced-usage/multiple-drivers.md
@@ -25,6 +25,7 @@ Printing::newPrintTask()
 
 // Send a job to the cups server
 Printing::driver('cups')
+    ->newPrintTask()
     ->printer($cupsPrinterId)
     ->file('file_path.pdf')
     ->send();

--- a/docs/advanced-usage/multiple-drivers.md
+++ b/docs/advanced-usage/multiple-drivers.md
@@ -1,0 +1,31 @@
+---
+title: Multiple Drivers
+sort: 5
+---
+
+## Introduction
+
+If you have multiple print drivers you need to print with, you can easily do so by calling
+`driver('driver_name')` on the `Printing` facade. This could be useful if you print receipts
+through PrintNode and then regular documents through CUPS or some other custom driver you have
+installed. 
+
+## Switching on the fly
+
+By default, the package only supports using one driver at a time, but you can switch to using a different driver
+at runtime if you need to. Let's say you need to print most documents using PrintNode, but for one specific document,
+you need to use CUPS. You can do so like this:
+
+```php
+// Send a job to printnode
+Printing::newPrintTask()
+    ->printer($printerId)
+    ->file('file_path.pdf')
+    ->send();
+
+// Send a job to the cups server
+Printing::driver('cups')
+    ->printer($cupsPrinterId)
+    ->file('file_path.pdf')
+    ->send();
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -53,6 +53,15 @@ return [
             'password' => env('CUPS_SERVER_PASSWORD'),
             'port' => env('CUPS_SERVER_PORT', 631),
         ],
+
+        /*
+         * Add your custom drivers here:
+         *
+         * 'custom' => [
+         *      'driver' => 'custom_driver',
+         *      // other config for your custom driver
+         * ],
+         */
     ],
 
     /*

--- a/src/Drivers/Cups/ContentType.php
+++ b/src/Drivers/Cups/ContentType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\Cups;
 
 class ContentType

--- a/src/Drivers/Cups/Cups.php
+++ b/src/Drivers/Cups/Cups.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\Cups;
 
 use Illuminate\Support\Collection;

--- a/src/Drivers/Cups/Entity/PrintJob.php
+++ b/src/Drivers/Cups/Entity/PrintJob.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\Cups\Entity;
 
 use Rawilk\Printing\Contracts\PrintJob as PrintJobContract;

--- a/src/Drivers/Cups/Entity/Printer.php
+++ b/src/Drivers/Cups/Entity/Printer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\Cups\Entity;
 
 use Illuminate\Contracts\Support\Arrayable;

--- a/src/Drivers/Cups/PrintTask.php
+++ b/src/Drivers/Cups/PrintTask.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\Cups;
 
 use Illuminate\Support\Str;

--- a/src/Drivers/Cups/Support/Client.php
+++ b/src/Drivers/Cups/Support/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\Cups\Support;
 
 use GuzzleHttp\Psr7\Uri;

--- a/src/Drivers/PrintNode/ContentType.php
+++ b/src/Drivers/PrintNode/ContentType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\PrintNode;
 
 class ContentType

--- a/src/Drivers/PrintNode/Entity/PrintJob.php
+++ b/src/Drivers/PrintNode/Entity/PrintJob.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\PrintNode\Entity;
 
 use Rawilk\Printing\Contracts\PrintJob as PrintJobContract;

--- a/src/Drivers/PrintNode/Entity/PrintNodePrintJob.php
+++ b/src/Drivers/PrintNode/Entity/PrintNodePrintJob.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\PrintNode\Entity;
 
 use PrintNode\Entity\PrintJob as PrintNodeEntity;

--- a/src/Drivers/PrintNode/Entity/Printer.php
+++ b/src/Drivers/PrintNode/Entity/Printer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\PrintNode\Entity;
 
 use Illuminate\Contracts\Support\Arrayable;

--- a/src/Drivers/PrintNode/PrintNode.php
+++ b/src/Drivers/PrintNode/PrintNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\PrintNode;
 
 use Illuminate\Support\Collection;

--- a/src/Drivers/PrintNode/PrintTask.php
+++ b/src/Drivers/PrintNode/PrintTask.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Drivers\PrintNode;
 
 use Illuminate\Support\Str;

--- a/src/Exceptions/DriverConfigNotFound.php
+++ b/src/Exceptions/DriverConfigNotFound.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Exceptions;
 
 use Exception;

--- a/src/Exceptions/InvalidDriverConfig.php
+++ b/src/Exceptions/InvalidDriverConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Exceptions;
 
 use Exception;

--- a/src/Exceptions/InvalidOption.php
+++ b/src/Exceptions/InvalidOption.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Exceptions;
 
 use Exception;

--- a/src/Exceptions/InvalidSource.php
+++ b/src/Exceptions/InvalidSource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Exceptions;
 
 use Exception;

--- a/src/Exceptions/PrintTaskFailed.php
+++ b/src/Exceptions/PrintTaskFailed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Exceptions;
 
 use Exception;

--- a/src/Exceptions/UnsupportedDriver.php
+++ b/src/Exceptions/UnsupportedDriver.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Printing\Exceptions;
+
+use Exception;
+
+class UnsupportedDriver extends Exception
+{
+    public static function driver(string $driver): self
+    {
+        return new static("Unsupported print driver: {$driver}");
+    }
+}

--- a/src/Facades/Printing.php
+++ b/src/Facades/Printing.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Facades;
 
 use Illuminate\Support\Facades\Facade;

--- a/src/Facades/Printing.php
+++ b/src/Facades/Printing.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Rawilk\Printing\Contracts\PrintTask newPrintTask()
  * @method static \Rawilk\Printing\Contracts\Printer|null find($printerId = null)
  * @method static \Illuminate\Support\Collection printers()
+ * @method static \Rawilk\Printing\Printing driver(?string $driver = null)
  */
 class Printing extends Facade
 {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -4,17 +4,20 @@ declare(strict_types=1);
 
 namespace Rawilk\Printing;
 
+use Closure;
 use Illuminate\Support\Arr;
 use Rawilk\Printing\Contracts\Driver;
 use Rawilk\Printing\Drivers\Cups\Cups;
 use Rawilk\Printing\Drivers\PrintNode\PrintNode;
 use Rawilk\Printing\Exceptions\DriverConfigNotFound;
 use Rawilk\Printing\Exceptions\InvalidDriverConfig;
+use Rawilk\Printing\Exceptions\UnsupportedDriver;
 
 class Factory
 {
     protected array $config;
     protected array $drivers = [];
+    protected array $customCreators = [];
 
     public function __construct(array $config)
     {
@@ -26,6 +29,13 @@ class Factory
         $driver = $driver ?: $this->getDriverFromConfig();
 
         return $this->drivers[$driver] = $this->get($driver);
+    }
+
+    public function extend(string $driver, Closure $callback): self
+    {
+        $this->customCreators[$driver] = $callback;
+
+        return $this;
     }
 
     protected function createCupsDriver(array $config): Driver
@@ -65,12 +75,29 @@ class Factory
 
     protected function resolve(string $driver): Driver
     {
+        if (isset($this->drivers[$driver])) {
+            return $this->drivers[$driver];
+        }
+
         $config = $this->getDriverConfig($driver);
 
         if (! is_array($config)) {
             throw DriverConfigNotFound::forDriver($driver);
         }
 
-        return $this->{'create'. ucfirst($driver) . 'Driver'}($config);
+        if (isset($this->customCreators[$config['driver'] ?? ''])) {
+            return $this->callCustomCreator($config);
+        }
+
+        if (! method_exists($this, $method = 'create' . ucfirst($driver) . 'Driver')) {
+            throw UnsupportedDriver::driver($driver);
+        }
+
+        return $this->$method($config);
+    }
+
+    protected function callCustomCreator(array $config): Driver
+    {
+        return $this->customCreators[$config['driver']]($config);
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing;
 
 use Illuminate\Support\Arr;

--- a/src/PrintTask.php
+++ b/src/PrintTask.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing;
 
 use Rawilk\Printing\Contracts\Printer;

--- a/src/Printing.php
+++ b/src/Printing.php
@@ -31,26 +31,50 @@ class Printing implements Driver
         return $this->defaultPrinterId;
     }
 
+    public function driver(?string $driver = null): self
+    {
+        $this->driver = app('printing.factory')->driver($driver);
+
+        return $this;
+    }
+
     public function newPrintTask(): \Rawilk\Printing\Contracts\PrintTask
     {
-        return $this->driver->newPrintTask();
+        $task = $this->driver->newPrintTask();
+
+        $this->resetDriver();
+
+        return $task;
     }
 
     public function find($printerId = null): ?Printer
     {
         try {
-            return $this->driver->find($printerId);
+            $printer = $this->driver->find($printerId);
         } catch (\Throwable $e) {
-            return null;
+            $printer = null;
         }
+
+        $this->resetDriver();
+
+        return $printer;
     }
 
     public function printers(): Collection
     {
         try {
-            return $this->driver->printers();
+            $printers = $this->driver->printers();
         } catch (\Throwable $e) {
-            return collect([]);
+            $printers = collect([]);
         }
+
+        $this->resetDriver();
+
+        return $printers;
+    }
+
+    private function resetDriver(): void
+    {
+        $this->driver();
     }
 }

--- a/src/Printing.php
+++ b/src/Printing.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing;
 
 use Illuminate\Support\Collection;

--- a/src/PrintingServiceProvider.php
+++ b/src/PrintingServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing;
 
 use Illuminate\Support\ServiceProvider;

--- a/src/Receipts/ReceiptPrinter.php
+++ b/src/Receipts/ReceiptPrinter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Receipts;
 
 use Illuminate\Support\Str;

--- a/tests/Feature/Drivers/Cups/Entity/JobTest.php
+++ b/tests/Feature/Drivers/Cups/Entity/JobTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Tests\Feature\Drivers\Cups\Entity;
 
 use Rawilk\Printing\Drivers\Cups\Entity\Printer;

--- a/tests/Feature/Drivers/Cups/Entity/PrinterTest.php
+++ b/tests/Feature/Drivers/Cups/Entity/PrinterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Tests\Feature\Drivers\Cups\Entity;
 
 use Rawilk\Printing\Drivers\Cups\Entity\Printer;

--- a/tests/Feature/Drivers/CustomDriver/CustomDriverTest.php
+++ b/tests/Feature/Drivers/CustomDriver/CustomDriverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Printing\Tests\Feature\Drivers\CustomDriver;
+
+use Rawilk\Printing\Facades\Printing;
+use Rawilk\Printing\Tests\Feature\Drivers\CustomDriver\Driver\CustomDriver;
+use Rawilk\Printing\Tests\TestCase;
+
+class CustomDriverTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'printing.driver' => 'custom',
+            'printing.drivers.custom' => [
+                'driver' => 'custom_driver',
+                'api_key' => '123456',
+            ],
+        ]);
+
+        $this->app['printing.factory']->extend('custom_driver', fn (array $config) => new CustomDriver($config['api_key']));
+    }
+
+    /** @test */
+    public function can_list_a_custom_drivers_printers(): void
+    {
+        self::assertCount(2, Printing::printers());
+        self::assertEquals('printer_one', Printing::printers()[0]->id());
+        self::assertEquals('printer_two', Printing::printers()[1]->id());
+    }
+
+    /** @test */
+    public function can_find_a_custom_drivers_printer(): void
+    {
+        $printer = Printing::find('printer_one');
+
+        self::assertEquals('printer_one', $printer->id());
+        self::assertTrue($printer->isOnline());
+    }
+
+    /** @test */
+    public function can_get_a_custom_drivers_default_printer(): void
+    {
+        config(['printing.default_printer_id' => 'printer_two']);
+
+        self::assertEquals('printer_two', Printing::defaultPrinterId());
+
+        $defaultPrinter = Printing::defaultPrinter();
+
+        self::assertEquals('printer_two', $defaultPrinter->id());
+        self::assertFalse($defaultPrinter->isOnline());
+    }
+
+    /** @test */
+    public function can_create_new_print_tasks_for_a_custom_driver(): void
+    {
+        $job = Printing::newPrintTask()
+            ->printer('printer_one')
+            ->content('hello world')
+            ->send();
+
+        self::assertEquals('success', $job->state());
+        self::assertEquals('printer_one', $job->printerId());
+    }
+}

--- a/tests/Feature/Drivers/CustomDriver/Driver/CustomDriver.php
+++ b/tests/Feature/Drivers/CustomDriver/Driver/CustomDriver.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Printing\Tests\Feature\Drivers\CustomDriver\Driver;
+
+use Illuminate\Support\Collection;
+use Rawilk\Printing\Contracts\Driver;
+use Rawilk\Printing\Contracts\Printer;
+use Rawilk\Printing\Contracts\PrintTask;
+use Rawilk\Printing\Tests\Feature\Drivers\CustomDriver\Driver\Entity\Printer as CustomDriverPrinter;
+use Rawilk\Printing\Tests\Feature\Drivers\CustomDriver\Driver\PrintTask as CustomDriverPrintTask;
+
+final class CustomDriver implements Driver
+{
+    public string $apiKey;
+
+    public function __construct(string $apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    public function newPrintTask(): PrintTask
+    {
+        return new CustomDriverPrintTask;
+    }
+
+    public function find($printerId = null): ?Printer
+    {
+        return $this->printers()
+            ->filter(fn (CustomDriverPrinter $p) => $p->id() === $printerId)
+            ->first();
+    }
+
+    public function printers(): Collection
+    {
+        return collect($this->customPrinters())
+            ->map(fn (array $data) => new CustomDriverPrinter($data))
+            ->values();
+    }
+
+    protected function customPrinters(): array
+    {
+        return [
+            [
+                'id' => 'printer_one',
+                'name' => 'Printer One',
+                'status' => 'online',
+                'capabilities' => [],
+                'description' => 'Printer one description',
+            ],
+            [
+                'id' => 'printer_two',
+                'name' => 'Printer Two',
+                'status' => 'offline',
+                'capabilities' => [],
+                'description' => 'Printer two description',
+            ],
+        ];
+    }
+}

--- a/tests/Feature/Drivers/CustomDriver/Driver/Entity/PrintJob.php
+++ b/tests/Feature/Drivers/CustomDriver/Driver/Entity/PrintJob.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Printing\Tests\Feature\Drivers\CustomDriver\Driver\Entity;
+
+use Rawilk\Printing\Contracts\PrintJob as PrintJobContract;
+
+final class PrintJob implements PrintJobContract
+{
+    private Printer $printer;
+
+    public function __construct(Printer $printer)
+    {
+        $this->printer = $printer;
+    }
+
+    public function date()
+    {
+        return '';
+    }
+
+    public function id()
+    {
+        return 1;
+    }
+
+    public function name(): ?string
+    {
+        return 'job name';
+    }
+
+    public function printerId()
+    {
+        return $this->printer->id();
+    }
+
+    public function printerName(): ?string
+    {
+        return $this->printer->name();
+    }
+
+    public function state(): ?string
+    {
+        return 'success';
+    }
+}

--- a/tests/Feature/Drivers/CustomDriver/Driver/Entity/Printer.php
+++ b/tests/Feature/Drivers/CustomDriver/Driver/Entity/Printer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Printing\Tests\Feature\Drivers\CustomDriver\Driver\Entity;
+
+use Illuminate\Support\Collection;
+use Rawilk\Printing\Contracts\Printer as PrinterContract;
+
+final class Printer implements PrinterContract
+{
+    private array $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function capabilities(): array
+    {
+        return $this->data['capabilities'];
+    }
+
+    public function description(): ?string
+    {
+        return $this->data['description'];
+    }
+
+    public function id(): string
+    {
+        return $this->data['id'];
+    }
+
+    public function isOnline(): bool
+    {
+        return $this->status() === 'online';
+    }
+
+    public function name(): ?string
+    {
+        return $this->data['name'];
+    }
+
+    public function status(): string
+    {
+        return $this->data['status'];
+    }
+
+    public function trays(): array
+    {
+        return $this->capabilities()['trays'] ?? [];
+    }
+
+    public function jobs(): Collection
+    {
+        return collect([]);
+    }
+}

--- a/tests/Feature/Drivers/CustomDriver/Driver/PrintTask.php
+++ b/tests/Feature/Drivers/CustomDriver/Driver/PrintTask.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rawilk\Printing\Tests\Feature\Drivers\CustomDriver\Driver;
+
+use Rawilk\Printing\Contracts\Printer;
+use Rawilk\Printing\Contracts\PrintJob;
+use Rawilk\Printing\Facades\Printing;
+use Rawilk\Printing\PrintTask as BasePrintTask;
+use Rawilk\Printing\Tests\Feature\Drivers\CustomDriver\Driver\Entity\PrintJob as CustomDriverPrintJob;
+
+final class PrintTask extends BasePrintTask
+{
+    public function range($start, $end = null): self
+    {
+        return $this;
+    }
+
+    public function send(): PrintJob
+    {
+        return new CustomDriverPrintJob($this->getPrinter());
+    }
+
+    private function getPrinter(): Printer
+    {
+        return Printing::find($this->printerId);
+    }
+}

--- a/tests/Feature/Drivers/PrintNode/Entity/PrinterTest.php
+++ b/tests/Feature/Drivers/PrintNode/Entity/PrinterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Tests\Feature\Drivers\PrintNode\Entity;
 
 use Rawilk\Printing\Drivers\PrintNode\Entity\Printer;

--- a/tests/Feature/Drivers/PrintNode/Fixtures/PrintNodePrinter.php
+++ b/tests/Feature/Drivers/PrintNode/Fixtures/PrintNodePrinter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Tests\Feature\Drivers\PrintNode\Fixtures;
 
 use Illuminate\Support\Str;

--- a/tests/Feature/Drivers/PrintNode/PrintNodeTest.php
+++ b/tests/Feature/Drivers/PrintNode/PrintNodeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Tests\Feature\Drivers\PrintNode;
 
 use Illuminate\Support\Collection;

--- a/tests/Feature/Drivers/PrintNode/PrintTaskTest.php
+++ b/tests/Feature/Drivers/PrintNode/PrintTaskTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Tests\Feature\Drivers\PrintNode;
 
 use Mockery;

--- a/tests/Feature/PrintingTest.php
+++ b/tests/Feature/PrintingTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Printing\Tests\Feature;
+
+use Rawilk\Printing\Drivers\PrintNode\PrintNode;
+use Rawilk\Printing\Drivers\PrintNode\PrintTask as PrintnodePrintTask;
+use Rawilk\Printing\Facades\Printing;
+use Rawilk\Printing\Tests\Feature\Drivers\CustomDriver\Driver\CustomDriver;
+use Rawilk\Printing\Tests\Feature\Drivers\CustomDriver\Driver\PrintTask as CustomDriverPrintTask;
+use Rawilk\Printing\Tests\TestCase;
+
+class PrintingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'printing.driver' => 'printnode',
+            'printing.drivers.custom' => [
+                'driver' => 'custom',
+                'api_key' => '123456',
+            ],
+        ]);
+
+        $this->app['printing.factory']->extend('custom', fn (array $config) => new CustomDriver($config['api_key']));
+    }
+
+    /** @test */
+    public function can_choose_drivers_at_runtime(): void
+    {
+        // Passing nothing into driver should give us the default driver
+        self::assertInstanceOf(PrintnodePrintTask::class, Printing::driver()->newPrintTask());
+
+        self::assertInstanceOf(PrintnodePrintTask::class, Printing::driver('printnode')->newPrintTask());
+        self::assertInstanceOf(CustomDriverPrintTask::class, Printing::driver('custom')->newPrintTask());
+    }
+
+    /** @test */
+    public function the_driver_should_use_the_default_driver_even_after_driver_method_has_been_called(): void
+    {
+        self::assertInstanceOf(PrintnodePrintTask::class, Printing::newPrintTask());
+        self::assertInstanceOf(CustomDriverPrintTask::class, Printing::driver('custom')->newPrintTask());
+
+        // should use the default (configured as printnode in our test)
+        self::assertInstanceOf(PrintnodePrintTask::class, Printing::newPrintTask());
+    }
+}

--- a/tests/Feature/Receipts/ReceiptPrinterTest.php
+++ b/tests/Feature/Receipts/ReceiptPrinterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rawilk\Printing\Tests\Feature\Receipts;
 
 use Mike42\Escpos\Printer;


### PR DESCRIPTION
This PR adds support to the package by allowing developers to define and use their own custom print drivers. You will also be able to call `Printing::driver('driver_name')` to change print drivers on-the-fly.