### PR TITLE
Fixing compatibility with Composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-json": "*",
         "illuminate/support": "^6.0|^7.0|^8.0",
         "mike42/escpos-php": "^3.0",
-        "php-http/socket-client": "2.*",
+        "php-http/socket-client": "^2.1",
         "printnode/printnode-php": "^2.0@RC",
         "smalot/cups-ipp": "^0.5.0"
     },


### PR DESCRIPTION
Many users of version 1 of this package now get the error `Interface 'Psr\Http\Client\ClientInterface' not found`. This is because `php-http/socket-client` states wrongfully  in it's `composer.json` file that it provides `psr/http-client`.

With Composer 1 this was not an issue, because Composer 1 installed `psr/http-client` anyway. But Composer 2 doesn't, breaking the installations of many users. By upgrading to `php-http/socket-client` `2.1` this is fixed. 