### PR TITLE
add support for printnode pdf_base64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-printing` will be documented in this file.
 
+## 2.0.1 - 2021-06-12
+### Updated
+- Add support for Printnode PDF_Base64 ContentType
+
 ## 2.0.0 - 2021-01-11
 ### Updated
 - Add support for php 8

--- a/src/Drivers/PrintNode/PrintTask.php
+++ b/src/Drivers/PrintNode/PrintTask.php
@@ -25,10 +25,15 @@ class PrintTask extends BasePrintTask
         $this->job = new PrintNodePrintJob($this->client);
     }
 
-    public function content($content): self
+    public function content($content, string $contentType = ContentType::RAW_BASE64): self
     {
+        if (! $contentType) {
+            throw new InvalidSource('Content type is required for the Printnode driver.');
+        }
+
+        parent::content($content);
         $this->job->content = base64_encode($content);
-        $this->job->contentType = ContentType::RAW_BASE64;
+        $this->job->contentType = $contentType;
 
         return $this;
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Fixes https://github.com/rawilk/laravel-printing/issues/22


4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Add support to set the contentType in the content() method of the Printnode driver.
Default is set with raw_base64 so everything should still work as expected, when no parameter is set.

