### PR TITLE
Add php 8.3 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,6 +34,8 @@ jobs:
                     -   laravel: 9.*
                         php: 8.2
                         stability: prefer-lowest
+                    -   laravel: 9.*
+                        php: 8.3
                     -   laravel: 8.*
                         php: 8.2
                         stability: prefer-lowest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,6 +37,8 @@ jobs:
                     -   laravel: 8.*
                         php: 8.2
                         stability: prefer-lowest
+                    -   laravel: 8.*
+                        php: 8.3
                     -   laravel: 11.*
                         php: 8.1
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [8.2, 8.1]
+                php: [8.3, 8.2, 8.1]
                 laravel: ['8.*', '9.*', '10.*', '11.*']
                 stability: [prefer-lowest, prefer-stable]
                 include:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^8.0|^8.1|^8.2",
+        "php": "^8.0|^8.1|^8.2|^8.3",
         "guzzlehttp/guzzle": "^7.5",
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
         "mike42/escpos-php": "^4.0",


### PR DESCRIPTION
PR adds support for php 8.3 on Laravel 10.x and above.