### PR TITLE
Add PHP 8.4 Compatibility

### DIFF
--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -38,11 +38,15 @@ jobs:
             stability: prefer-lowest
           - laravel: 9.*
             php: 8.3
+          - laravel: 9.*
+            php: 8.4
           - laravel: 8.*
             php: 8.2
             stability: prefer-lowest
           - laravel: 8.*
             php: 8.3
+          - laravel: 8.*
+            php: 8.4
           - laravel: 11.*
             php: 8.1
           - laravel: 12.*

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3, 8.2, 8.1]
+        php: [8.4, 8.3, 8.2, 8.1]
         laravel: [12.*, 11.*, 10.*, 9.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^8.0|^8.1|^8.2|^8.3",
+        "php": "^8.0",
         "guzzlehttp/guzzle": "^7.5",
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "mike42/escpos-php": "^4.0",


### PR DESCRIPTION
PR adds php 8.4 version to the testing matrix to ensure compatibility.
