### PR TITLE
Fix: allow macro calls on the ReceiptPrinter class

### DIFF
--- a/src/Receipts/ReceiptPrinter.php
+++ b/src/Receipts/ReceiptPrinter.php
@@ -42,7 +42,9 @@ use Mike42\Escpos\Printer;
 class ReceiptPrinter
 {
     use Conditionable;
-    use Macroable;
+    use Macroable {
+        Macroable::__call as __macroCall;
+    }
 
     protected DummyPrintConnector $connector;
 
@@ -68,15 +70,15 @@ class ReceiptPrinter
         return $this->connector->getData();
     }
 
-    public function __call($name, $arguments)
+    public function __call($method, $parameters)
     {
-        if (method_exists($this->printer, $name)) {
-            $this->printer->{$name}(...$arguments);
+        if (method_exists($this->printer, $method)) {
+            $this->printer->{$method}(...$parameters);
 
             return $this;
         }
 
-        throw new InvalidArgumentException("Method [{$name}] not found on receipt printer object.");
+        return $this->__macroCall($method, $parameters);
     }
 
     public function centerAlign(): self


### PR DESCRIPTION
The original ReceiptPrinter class overrides `Macroable::__call($method, $parameters)`, keeping any macros from being executed, as an InvalidArgumentException will _always_ be thrown as macros in fact don't exist within the ReceiptPrinter class as methods.

```php
public function __call($name, $arguments)
{
    if (method_exists($this->printer, $name)) {
        $this->printer->{$method}(...$parameters);

        return $this;
    }

    // this will always be thrown for macros...
    throw new InvalidArgumentException("Method [{$name}] not found on receipt printer object.");
}
```

I fixed this by calling the traits original __call() method after checking for existing methods on the printer class.

I've also aligned the parameter names with the Macroable traits method: `$name` => `$method`, `$arguments` => `$parameters`.