### PR TITLE
PrintNodeApiRequestor incorrectly casts booleans to strings

### DIFF
--- a/src/Api/PrintNode/PrintNodeApiRequestor.php
+++ b/src/Api/PrintNode/PrintNodeApiRequestor.php
@@ -72,12 +72,12 @@ class PrintNodeApiRequestor
             return Util::utf8($objects->id);
         }
 
-        if ($objects === true) {
-            return 'true';
+        if ($objects === 'true') {
+            return true;
         }
 
-        if ($objects === false) {
-            return 'false';
+        if ($objects === 'false') {
+            return false;
         }
 
         if (is_array($objects)) {

--- a/tests/Feature/Api/PrintNode/PrintNodeApiRequestorTest.php
+++ b/tests/Feature/Api/PrintNode/PrintNodeApiRequestorTest.php
@@ -59,11 +59,19 @@ test('encode objects', function (mixed $value, mixed $expected) {
     ],
     'boolean true' => fn () => [
         'value' => true,
-        'expected' => 'true',
+        'expected' => true,
+    ],
+    'string boolean true' => fn () => [
+        'value' => 'true',
+        'expected' => true,
     ],
     'boolean false' => fn () => [
         'value' => false,
-        'expected' => 'false',
+        'expected' => false,
+    ],
+    'string boolean false' => fn () => [
+        'value' => 'false',
+        'expected' => false,
     ],
 ]);
 


### PR DESCRIPTION
PrintNodeApiRequestor::encodeObjects() is casting boolean option values to strings, while the PrintNode API specifically only accepts Boolean types. This PR ensures a string is cast to a Boolean type, and Boolean types are sent as-is.

Error response from the API: 
```
Incorrect request body: (request body).options.fit_to_page must be a boolean
```

Original output from `static::encodeObjects`:
![image](https://github.com/user-attachments/assets/e402aaf1-88b2-453e-82cf-1161cf9b8a34)

Updated output from `static::encodeObjects`:
![image](https://github.com/user-attachments/assets/b3b38f5c-53ad-4927-aff8-1880bff7f321)
