### PR TITLE
[Bug]: Cups Config Issues

### DIFF
--- a/config/printing.php
+++ b/config/printing.php
@@ -34,7 +34,7 @@ return [
             'ip' => env('CUPS_SERVER_IP'),
             'username' => env('CUPS_SERVER_USERNAME'),
             'password' => env('CUPS_SERVER_PASSWORD'),
-            'port' => env('CUPS_SERVER_PORT'),
+            'port' => (int) env('CUPS_SERVER_PORT'),
             'secure' => env('CUPS_SERVER_SECURE'),
         ],
 

--- a/config/printing.php
+++ b/config/printing.php
@@ -25,12 +25,10 @@ return [
     */
     'drivers' => [
         PrintDriver::PrintNode->value => [
-            'driver' => PrintDriver::PrintNode->value,
             'key' => env('PRINT_NODE_API_KEY'),
         ],
 
         PrintDriver::Cups->value => [
-            'driver' => PrintDriver::Cups->value,
             'ip' => env('CUPS_SERVER_IP'),
             'username' => env('CUPS_SERVER_USERNAME'),
             'password' => env('CUPS_SERVER_PASSWORD'),


### PR DESCRIPTION
Issue #110 points out that the default config from the package does not work as is. The `port` key needs to be cast to an integer, otherwise it's interpreted as a string. 

The CUPS api client also does some checking to see if there are any extra config keys present and throws an error if there are any.  Since the `driver` key is no longer necessary for this package to resolve the drivers that the package supports, I'm going to just remove the keys from the config.
