### PR TITLE
Fix cups usage by using correct request class name in CupsRequestor

### DIFF
--- a/src/Api/Cups/CupsRequestor.php
+++ b/src/Api/Cups/CupsRequestor.php
@@ -29,10 +29,10 @@ class CupsRequestor
     }
 
     public function request(
-        string|PendingRequest $binary,
+        string|HttpRequest $binary,
         RequestOptions $opts,
     ): CupsResponse {
-        if ($binary instanceof PendingRequest) {
+        if ($binary instanceof HttpRequest) {
             $binary = $binary->encode();
         }
 
@@ -43,7 +43,7 @@ class CupsRequestor
             ->withBody($binary, self::CONTENT_TYPE)
             ->when(
                 filled($username) || filled($password),
-                fn (PendingRequest $request) => $request->withBasicAuth($username ?? '', $password ?? ''),
+                fn (HttpRequest $request) => $request->withBasicAuth($username ?? '', $password ?? ''),
             );
 
         $response = $client->post($adminUrl)->throwIfClientError();


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
I need this library to direct print from my Laravel app with cups.
I did not create an issue first, should I do so? (sorry this is my first pull request).

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No written test, but I did test with this line, and it works:
`Printing::newPrintTask()->printer("ipp://localhost:631/printers/MY_PRINTER")->file('MY_FILE.pdf')->send()`

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
I fixed the class name in `CupsRequestor`: `HttpRequest` instead of `PendingRequest`

5️⃣ Thanks for contributing! 🙌
